### PR TITLE
Make dev env easier to start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,26 @@
-MONGODB_URI=<db-uri>
-MONGODB_USER=<user>
-MONGODB_PASS=<user-pass>
-MONGODB_ADMIN_USER=<admin-user>
-MONGODB_ADMIN_PASS=<admin-pass>
+# Production
+
+# Mongo DB URI
+MONGODB_URI=
+# User to use to connect to the database (Non root user)
+MONGODB_USER=
+# Password of the non root user
+MONGODB_PASS=
+# Admin user to be used by mongo image
+MONGODB_ADMIN_USER=
+# Password of the admin user
+MONGODB_ADMIN_PASS=
+# Admin DB to be used by the mongo image
+MONGODB_INIT_DATABASE=
+# Platzily DB name
+MONGODB_DATABASE=
+
+# Development
+
+DEV_MONGODB_URI=
+DEV_MONGODB_USER=
+DEV_MONGODB_PASS=
+DEV_MONGODB_ADMIN_USER=
+DEV_MONGODB_ADMIN_PASS=
+DEV_MONGODB_INIT_DATABASE=
+DEV_MONGODB_DATABASE=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# platzily
+# Platzily
+
+## Development environment
+
+This part of the documentation assumes that you have [docker-compose](https://docs.docker.com/compose) installed
+
+On the root of the project run the following command
+
+```bash
+cat .env.example > .env
+```
+
+Fill all the environment variables on the `.env` file
+
+```bash
+yarn dev
+```
+
+Now you should have
+
+- A container running mongo on port 27017
+- A container running the api-gw on port 3100
+- A hot reloading api-gw process running on port 3000

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ cat .env.example > .env
 Fill all the environment variables on the `.env` file
 
 ```bash
+yarn start:database
+```
+
+Wait for the databases to fill and run the following command
+
+```bash
 yarn dev
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - mongo-db
     ports:
-      - "3000:3000"
+      - "3100:3100"
     container_name: api-gw
     restart: on-failure
     links:
@@ -17,18 +17,23 @@ services:
       - platzily-network
     volumes:
       - ".env:/src/.env"
-    
+
   mongo-db:
     image: mongo
     container_name: mongo_db
     restart: unless-stopped
     command: [--auth]
-    environment: 
+    environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGODB_ADMIN_USER}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGODB_ADMIN_PASS}
+      - MONGODB_USER=${MONGODB_USER}
+      - MONGODB_PASS=${MONGODB_PASS}
+      - MONGO_INITDB_DATABASE=${MONGODB_INIT_DATABASE}
+      - MONGODB_DATABASE=${MONGODB_DATABASE}
     ports:
       - "27017:27017"
     volumes:
+      - ./scripts/init-mongo.sh:/docker-entrypoint-initdb.d/init-mongo.sh
       - ./data:/data/db
     networks:
       - platzily-network

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "packages/*"
   ],
   "scripts": {
-    "start:server": "yarn workspace @platzily/api-gw start"
+    "start:server": "yarn workspace @platzily/api-gw start",
+    "start:server:dev": "yarn workspace @platzily/api-gw start:dev",
+    "dev": "docker-compose up -d && sleep 5 && yarn start:server:dev"
   },
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start:server": "yarn workspace @platzily/api-gw start",
     "start:server:dev": "yarn workspace @platzily/api-gw start:dev",
-    "dev": "docker-compose up -d && sleep 5 && yarn start:server:dev"
+    "start:database": "docker-compose up -d",
+    "dev": "yarn start:server:dev"
   },
   "private": true,
   "devDependencies": {

--- a/packages/mongodb-connection-module/config/environment.js
+++ b/packages/mongodb-connection-module/config/environment.js
@@ -1,5 +1,6 @@
 const dotenv = require('dotenv');
 const { supportedEnvs } = require('../src/utils/constants');
+const { join } = require('path')
 
 let environment;
 let path;
@@ -13,7 +14,7 @@ switch (process.env.NODE_ENV) {
   }
   default: {
     environment = 'DEV_';
-    path = `${process.env.HOME}/${env}`;
+    path = `${join(__dirname, '../../..')}/${env}`;
 
     break;
   }

--- a/scripts/init-mongo.sh
+++ b/scripts/init-mongo.sh
@@ -1,0 +1,18 @@
+mongo -- "$MONGO_INITDB_DATABASE" <<EOF
+use $MONGO_INITDB_DATABASE;
+
+db.auth('$MONGO_INITDB_ROOT_USERNAME', '$MONGO_INITDB_ROOT_PASSWORD');
+
+use $MONGODB_DATABASE;
+
+db.createUser({
+  user: '$MONGODB_USER',
+  pwd: '$MONGODB_PASS',
+  roles: [{
+    role: 'readWrite',
+    db: '$MONGODB_DATABASE'
+  }]
+});
+
+db.config.insert({'test': 'hello'});
+EOF


### PR DESCRIPTION
resolves #43 

At the moment is not easy to start the application, a docker must be run then the developers needs to access the database and create a new user and db, all these tasks can be automatized. 

- Changed the .env file location when using development to let the file live inside the project and not the user home folder.
- Created a initdb script to automatize some process the developers where doing manually after creating the db
- Made the development environment liftable by running a single dev command

I think this is a good first step on making easier to lift a local dev env. 

![](https://media3.giphy.com/media/smkXeUEOSbkwE/giphy.gif)